### PR TITLE
Fix support for deserializing optional parameters

### DIFF
--- a/booby/models.py
+++ b/booby/models.py
@@ -200,7 +200,10 @@ class Model(object):
         result = {}
 
         for name, field in self._fields.items():
-            value = raw[field.options.get('name', name)]
+            try:
+                value = raw[field.options.get('name', name)]
+            except KeyError:
+                continue
 
             if (isinstance(value, collections.MutableMapping) and
                 isinstance(field, fields.Embedded)):

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -228,6 +228,11 @@ class TestDeserializeModel(object):
 
         expect(result).to.have.keys(name='Jack', email='jack@example.com')
 
+    def test_should_return_dict_with_model_fields_when_fields_are_missing(self):
+        result = User.deserialize({'name': 'Jack'})
+
+        expect(result).to.have.keys(name='Jack')
+
     def test_should_deserialize_embedded_dict_if_field_is_embedded_field(self):
         result = UserWithTokenAndMappedFields.deserialize({
             'name': 'Jack', 'email': 'jack@example.com',


### PR DESCRIPTION
Without this change, `deserialize()` raises KeyError when some field values are missing.
