### PR TITLE
Support read-only fields, which are treated normally in decoding but omitted during encoding

### DIFF
--- a/booby/fields.py
+++ b/booby/fields.py
@@ -57,6 +57,7 @@ class Field(object):
 
     :param required: If `True` this field value should not be `None`.
     :param choices: A `list` of values where this field value should be in.
+    :param read_only: If `True`, the value is treated normally in decoding but omitted during encoding.
     :param \*validators: A list of field :mod:`validators` as positional arguments.
 
     """

--- a/booby/mixins.py
+++ b/booby/mixins.py
@@ -20,4 +20,5 @@ class Encoder(object):
         return {
             field.options.get('name', name): field.encode(getattr(self, name))
                 for name, field in self._fields.items()
+                if not field.options.get('read_only', False)
         }

--- a/tests/unit/models/test_decode.py
+++ b/tests/unit/models/test_decode.py
@@ -9,6 +9,7 @@ IRRELEVANT_NAME = 'irrelevant name'
 IRRELEVANT_EMAIL = 'irrelevant email'
 DECODED_IRRELEVANT_NAME = 'decoded irrelevant name'
 DECODED_IRRELEVANT_EMAIL = 'decoded irrelevant email'
+IRRELEVANT_DATE = 'irrelevant date'
 
 
 class TestDecodeModel(object):
@@ -46,6 +47,21 @@ class TestDecodeModel(object):
         result = User.decode({'name': IRRELEVANT_NAME})
 
         expect(result).to(have_keys(name=IRRELEVANT_NAME))
+
+    def test_should_include_read_only_field(self):
+        class User(models.Model):
+            name = fields.Field()
+            last_update = fields.Field(read_only=True)
+
+        user = User(name=IRRELEVANT_NAME, last_update=IRRELEVANT_DATE)
+
+        result = User.decode({
+            'name': IRRELEVANT_NAME,
+            'last_update': IRRELEVANT_DATE
+        })
+
+        expect(result).to(have_keys(name=IRRELEVANT_NAME,
+                                    last_update=IRRELEVANT_DATE))
 
 
 class StubField(fields.Field):

--- a/tests/unit/models/test_encode.py
+++ b/tests/unit/models/test_encode.py
@@ -9,6 +9,7 @@ IRRELEVANT_NAME = 'irrelevant name'
 IRRELEVANT_EMAIL = 'irrelevant email'
 ENCODED_IRRELEVANT_NAME = 'encoded irrelevant name'
 ENCODED_IRRELEVANT_EMAIL = 'encoded irrelevant email'
+IRRELEVANT_DATE = 'irrelevant date'
 
 
 class TestEncodeModel(object):
@@ -35,6 +36,18 @@ class TestEncodeModel(object):
 
         expect(result).to(have_keys(username=IRRELEVANT_NAME,
                                     emailAddress=IRRELEVANT_EMAIL))
+
+    def test_should_skip_read_only_field(self):
+        class User(models.Model):
+            name = fields.Field()
+            last_update = fields.Field(read_only=True)
+
+        user = User(name=IRRELEVANT_NAME, last_update=IRRELEVANT_DATE)
+
+        result = user.encode()
+
+        expect(result).to(have_keys(name=IRRELEVANT_NAME))
+        expect(result).not_to(have_keys(last_update=IRRELEVANT_DATE))
 
 
 class StubField(fields.Field):


### PR DESCRIPTION
This is useful for fields in an API like "last update" or "created on", which are useful to decode, but shouldn't ever be sent back to the server.

Here's a [real life example](http://developer.capsulecrm.com/v1/resources/parties/).
