### PR TITLE
Use hasattr() rather than isinstance(value, MutableSequence)

### DIFF
--- a/booby/encoders.py
+++ b/booby/encoders.py
@@ -37,7 +37,7 @@ class List(Encoder):
 
     @nullable
     def encode(self, value):
-        if not isinstance(value, collections.MutableSequence):
+        if not hasattr(value, '__iter__'):
             raise errors.EncodeError()
 
         result = []

--- a/booby/fields.py
+++ b/booby/fields.py
@@ -245,7 +245,7 @@ class Collection(Field):
         self.model = model
 
     def __set__(self, instance, value):
-        if isinstance(value, collections.MutableSequence):
+        if hasattr(value, '__iter__'):
             value = self._resolve(value)
 
         super(Collection, self).__set__(instance, value)

--- a/booby/models.py
+++ b/booby/models.py
@@ -110,13 +110,18 @@ class Model(mixins.Encoder):
 
             if isinstance(value, Model):
                 value = dict(value)
-            elif isinstance(value, collections.MutableSequence):
-                value = self._encode_sequence(value)
+            if hasattr(value, '__iter__'):
+                value = self._encode_iterable(value)
 
             yield name, value
 
-    def _encode_sequence(self, sequence):
+    def _encode_iterable(self, sequence):
         result = []
+
+        if isinstance(sequence, dict):
+            # Although iterable, dictionaries are a special
+            # case and should be used as-is
+            return sequence
 
         for value in sequence:
             if isinstance(value, Model):

--- a/booby/validators.py
+++ b/booby/validators.py
@@ -157,7 +157,7 @@ class List(Validator):
 
     @nullable
     def validate(self, value):
-        if not isinstance(value, collections.MutableSequence):
+        if not hasattr(value, '__iter__'):
             raise errors.ValidationError('should be a list')
 
         for i in value:

--- a/tests/unit/models/test_model.py
+++ b/tests/unit/models/test_model.py
@@ -177,7 +177,6 @@ class TestModelToDict(object):
 
         user = dict(UserWithToken(name='foo', email='roo@example.com',
                                   token=self.token1))
-
         expect(user).to(have_keys(
             name='foo',
             email='roo@example.com',


### PR DESCRIPTION
There are several places where the code checks specifically if something is an instance ``MutableSequence``. I believe the [more pythonic](https://www.google.co.uk/search?q=python+isinstance+considered+harmful) way would be something like:

``` python
# rather than this
if isinstance(value, collections.MutableSequence):
# do this:
if hasattr(value, '__iter__'):
```

From what I can see, iterability is what is actually desired, the other functionality of ``MutableSequence`` isn't needed.

For example, I have an object which is iterable and should therefore (AFAIK) be able to be decoded into a collection. However, right now it fails the check for being a ``MutableSequence``.

This is potentially an extension of issue #18 from last year.