### PR TITLE
Prepend field name to ValidationError messages

### DIFF
--- a/booby/models.py
+++ b/booby/models.py
@@ -174,12 +174,16 @@ class Model(mixins.Encoder):
         all the :mod:`fields` within this model.
 
         If some `field` validation fails, then this method raises the same
-        exception that the :func:`field.validate` method had raised.
+        exception that the :func:`field.validate` method had raised, but
+        with the field name prepended.
 
         """
 
         for name, field in self._fields.items():
-            field.validate(getattr(self, name))
+            try:
+                field.validate(getattr(self, name))
+            except errors.ValidationError as err:
+                raise errors.ValidationError('%s %s' % (name, err))
 
     @property
     def validation_errors(self):

--- a/tests/integration/test_model.py
+++ b/tests/integration/test_model.py
@@ -26,7 +26,7 @@ class TestValidation(object):
             user.validate()
 
         expect(callback).to(raise_error(errors.ValidationError,
-                                        'should be an integer'))
+                                        'karma should be an integer'))
 
     def test_should_fail_validation_if_token_key_is_not_a_string(self):
         def callback():
@@ -34,7 +34,7 @@ class TestValidation(object):
             user.validate()
 
         expect(callback).to(raise_error(errors.ValidationError,
-                                        'should be a string'))
+                                        'token key should be a string'))
 
     def test_should_fail_validation_if_invalid_email(self):
         def callback():
@@ -42,7 +42,7 @@ class TestValidation(object):
             user.validate()
 
         expect(callback).to(raise_error(errors.ValidationError,
-                                        'should be a valid email'))
+                                        'email should be a valid email'))
 
 
 class TestEncode(object):

--- a/tests/unit/models/test_model.py
+++ b/tests/unit/models/test_model.py
@@ -52,7 +52,7 @@ class TestValidateModel(object):
         user = UserWithRequiredName(email='foo@example.com')
 
         expect(lambda: user.validate()).to(raise_error(
-            errors.ValidationError, 'is required'))
+            errors.ValidationError, 'name is required'))
 
     def test_when_validate_without_errors_then_does_not_raise(self):
         user = UserWithRequiredName(name='Jack')
@@ -84,6 +84,12 @@ class TestValidateModel(object):
         errors = user.validation_errors
 
         expect(errors).to(be_empty)
+
+    def test_exceptions_contain_field_names(self):
+        user = UserWithRequiredName()
+
+        expect(user.validate).to(raise_error(errors.ValidationError,
+                                             'name is required'))
 
 
 class TestInheritedModel(object):
@@ -123,7 +129,7 @@ class TestInheritedMixin(object):
         user = User()
 
         expect(lambda: user.validate()).to(raise_error(
-            errors.ValidationError, 'is required'))
+            errors.ValidationError, 'name is required'))
 
 
 class TestDictModel(object):


### PR DESCRIPTION
Given a ValidationError, it is currently difficult to see field is invalid. I know we can look in Model.validation_errors, but I'd prefer to include the field name in ValidationError messages.